### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/cslibby/cac6f41d-5fb5-4e64-89e1-b1b44cd25cb7/9ff8b643-6723-4e93-b0e7-7672a577c319/_apis/work/boardbadge/dc252038-e583-4965-80d8-efde453d7d6c)](https://dev.azure.com/cslibby/cac6f41d-5fb5-4e64-89e1-b1b44cd25cb7/_boards/board/t/9ff8b643-6723-4e93-b0e7-7672a577c319/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/cslibby/cac6f41d-5fb5-4e64-89e1-b1b44cd25cb7/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.